### PR TITLE
Update N-Excavator.json

### DIFF
--- a/Additional Miners/N-Excavator.json
+++ b/Additional Miners/N-Excavator.json
@@ -1,7 +1,7 @@
 {
 "Path" : ".\\Bin\\Excavator\\Excavator.exe",
 "ExtractionPath" : ".\\Bin\\Excavator\\",
-"Uri" : "https://github.com/nicehash/excavator/releases/download/v1.3.7a/excavator_v1.3.7a_NVIDIA_Win64.zip",
+"Uri" : "https://github.com/nicehash/excavator/releases/download/v1.4.2a/excavator_v1.4.2a_NVIDIA_Win64.zip",
 "Types" : ["NVIDIA"],
 "GenerateConfigFile" : ".\\Bin\\Excavator\\#GROUPNAME#.json",
 "PatternConfigFile": ".\\Patterns\\excavatorPattern.txt",
@@ -13,10 +13,10 @@
 "Fee":"0",
 "Algorithms": [
             {"Lyra2v2":"lyra2rev2"}
+            {"Nist5":"nist5"}
             ]
 
 }
 
 
   
- 


### PR DESCRIPTION
Updated Uri to the new Excavator release 1.4.2a

Added nist5 to supported algorithms as it performs better then other miners included