### PR TITLE
Update N-CcminerX16r.json

### DIFF
--- a/Miners/N-CcminerX16r.json
+++ b/Miners/N-CcminerX16r.json
@@ -10,8 +10,7 @@
 "PrelaunchCommand":"",
 "Algorithms": [
                 {"x16r":"-a x16r"},
-                {"x16r":"-a x16s"},
-			    {"x17":"-a x17"}
+                {"x16s":"-a x16s"}
 
               ]
 }


### PR DESCRIPTION
Assuming the second x16r entry was a typo of x16s. x17 seems to endlessly error out, removing.